### PR TITLE
feat: limit the users who can use the telegram

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,4 @@ ADDR=:8080
 
 # Telegram client config
 BOT_TOKEN=<telegram-bot-token>
+USERNAME_LIMITS=

--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ If you add a caption to an image it will be used as the question.
 Env variables:
 - `BOT_TOKEN` - The token of the bot you created in Telegram
 - `AI_SERVICE` - AI service (the server-bot's) address (Default: `http://127.0.0.1:8080`)
+- `USERNAME_LIMITS` - A comma separated list of usernames that are allowed to use the bot (Default: `""`, means everybody can use it)
 
 
 #### Facebook messenger client


### PR DESCRIPTION
Now you can set the username in an env var who can access the bot.
Everybody else will be rejected.