### PR TITLE
⚡ Pre-allocate slice capacity for user prompt parts

### DIFF
--- a/internal/ai/agent/logic.go
+++ b/internal/ai/agent/logic.go
@@ -127,7 +127,7 @@ func (l *Logic) HandleMessage(ctx context.Context, sessionID string, req domain.
 		}
 	}
 
-	userPromptParts := make([]*ai.Part, 0)
+	userPromptParts := make([]*ai.Part, 0, len(req.InlineData)+1)
 	for _, inlineData := range req.InlineData {
 		// If we have some inline data convert them to prompt parts
 		userPromptParts = append(userPromptParts, ai.NewMediaPart(inlineData.MimeType, string(inlineData.Data)))


### PR DESCRIPTION
💡 **What:** Modified `internal/ai/gemini/logic.go` to pre-allocate the capacity of the `userPromptParts` slice using `make([]*ai.Part, 0, len(req.InlineData)+1)`.

🎯 **Why:** To prevent multiple underlying array re-allocations as `req.InlineData` and the final `req.Message` are appended to the slice, improving memory efficiency.

📊 **Measured Improvement:** Direct measurement with `go test -bench` was not possible in this environment due to restricted internet access and timeout issues when fetching dependencies. However, pre-allocating slice capacity is a well-established Go best practice that reduces CPU cycles spent on memory management and copying during slice growth. By setting the capacity to `len(req.InlineData) + 1`, the slice is guaranteed to fit all elements without resizing.

---
*PR created automatically by Jules for task [11223308840990628517](https://jules.google.com/task/11223308840990628517) started by @Gerifield*