### PR TITLE
refactor: extract genkit summarizer and embedding into own packages

### DIFF
--- a/cmd/server-bot/main.go
+++ b/cmd/server-bot/main.go
@@ -13,12 +13,12 @@ import (
 
 	"hairy-botter/internal/ai/agent"
 	"hairy-botter/internal/ai/gemini"
-	gemini_embedding "hairy-botter/internal/ai/gemini-embedding"
+	genkit_embedding "hairy-botter/internal/ai/genkit-embedding"
+	genkit_summarizer "hairy-botter/internal/ai/genkit-summarizer"
 	"hairy-botter/internal/history"
 	"hairy-botter/internal/rag"
 	"hairy-botter/internal/server"
 
-	"github.com/firebase/genkit/go/ai"
 	"github.com/firebase/genkit/go/genkit"
 )
 
@@ -38,23 +38,6 @@ func logLevelEnv() slog.Level {
 	}
 }
 
-// genkitSummarizer implements history.Summarizer using the genkit framework.
-type genkitSummarizer struct {
-	g     *genkit.Genkit
-	model ai.Model
-}
-
-func (s *genkitSummarizer) Summarize(ctx context.Context, systemPrompt, text string) (string, error) {
-	resp, err := genkit.Generate(ctx, s.g,
-		ai.WithModel(s.model),
-		ai.WithSystem(systemPrompt),
-		ai.WithMessages(ai.NewUserTextMessage(text)),
-	)
-	if err != nil {
-		return "", err
-	}
-	return resp.Text(), nil
-}
 
 func main() {
 
@@ -123,8 +106,7 @@ func main() {
 		return
 	}
 
-	ragEmbedder := gemini_embedding.EmbeddingFunc(g, embedder)
-	ragL, err := rag.New(logger, "bot-context/", ragEmbedder)
+	ragL, err := rag.New(logger, "bot-context/", rag.EmbeddingFunc(genkit_embedding.New(g, embedder)))
 	if err != nil {
 		logger.Error("failed to create RAG logic", slog.String("err", err.Error()))
 
@@ -133,10 +115,7 @@ func main() {
 
 	hist := history.New(logger, "history-gemini/", history.Config{
 		HistorySummary: historySummary,
-		Summarizer: &genkitSummarizer{
-			g:     g,
-			model: model,
-		},
+		Summarizer:     genkit_summarizer.New(g, model),
 	})
 
 	aiLogic, err := agent.New(logger, g, model, hist, mcpClientAddrs, ragL, customModelConfig)

--- a/internal/ai/genkit-embedding/embedding.go
+++ b/internal/ai/genkit-embedding/embedding.go
@@ -1,4 +1,4 @@
-package gemini_embedding
+package genkit_embedding
 
 import (
 	"context"
@@ -6,11 +6,14 @@ import (
 
 	"github.com/firebase/genkit/go/ai"
 	"github.com/firebase/genkit/go/genkit"
-	"github.com/philippgille/chromem-go"
 )
 
-// EmbeddingFunc .
-func EmbeddingFunc(g *genkit.Genkit, embedder ai.Embedder) chromem.EmbeddingFunc {
+// Func is a function that embeds text into a float32 vector.
+// It matches the chromem.EmbeddingFunc signature so it can be used directly with chromem.
+type Func func(ctx context.Context, text string) ([]float32, error)
+
+// New returns an embedding Func backed by the given genkit embedder.
+func New(g *genkit.Genkit, embedder ai.Embedder) Func {
 	return func(ctx context.Context, text string) ([]float32, error) {
 		resp, err := genkit.Embed(ctx, g, ai.WithEmbedder(embedder), ai.WithTextDocs(text))
 		if err != nil {

--- a/internal/ai/genkit-summarizer/summarizer.go
+++ b/internal/ai/genkit-summarizer/summarizer.go
@@ -1,0 +1,33 @@
+package genkit_summarizer
+
+import (
+	"context"
+
+	"hairy-botter/internal/history"
+
+	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/genkit"
+)
+
+type summarizer struct {
+	g     *genkit.Genkit
+	model ai.Model
+}
+
+// New returns a history.Summarizer backed by the given genkit model.
+func New(g *genkit.Genkit, model ai.Model) history.Summarizer {
+	return &summarizer{g: g, model: model}
+}
+
+func (s *summarizer) Summarize(ctx context.Context, systemPrompt, text string) (string, error) {
+	resp, err := genkit.Generate(ctx, s.g,
+		ai.WithModel(s.model),
+		ai.WithSystem(systemPrompt),
+		ai.WithMessages(ai.NewUserTextMessage(text)),
+	)
+	if err != nil {
+		return "", err
+	}
+
+	return resp.Text(), nil
+}

--- a/internal/rag/rag.go
+++ b/internal/rag/rag.go
@@ -14,6 +14,10 @@ import (
 	"github.com/philippgille/chromem-go"
 )
 
+// EmbeddingFunc is a function that converts text into a float32 vector.
+// It is compatible with chromem.EmbeddingFunc.
+type EmbeddingFunc func(ctx context.Context, text string) ([]float32, error)
+
 const (
 	collectionKey = "rag-content"
 	dbSaveName    = "database.db"
@@ -26,18 +30,18 @@ type Logic struct {
 
 	db           *chromem.DB // Database for RAG content
 	embeddedDocs int
-	embedFn      chromem.EmbeddingFunc
+	embedFn      EmbeddingFunc
 }
 
 // New .
-func New(logger *slog.Logger, ragPath string, embedder chromem.EmbeddingFunc) (*Logic, error) {
+func New(logger *slog.Logger, ragPath string, embedder EmbeddingFunc) (*Logic, error) {
 	logger.Info("try to load RAG db")
 	db, err := loadSavedDB(ragPath)
 	if err != nil {
 		// Doesn't exist or failed, recreate it
 		logger.Info("init new RAG db")
 		db = chromem.NewDB()
-		_, err := db.CreateCollection(collectionKey, nil, embedder) // Just to make sure the collection exists
+		_, err := db.CreateCollection(collectionKey, nil, chromem.EmbeddingFunc(embedder)) // Just to make sure the collection exists
 		if err != nil {
 			logger.Error("failed to create RAG collection", slog.String("collection", collectionKey), slog.String("error", err.Error()))
 
@@ -75,7 +79,7 @@ func (l *Logic) loadContent() error {
 	dir := os.DirFS(l.ragPath)
 
 	// we need to set embed function since we might have loaded an existing db
-	coll := l.db.GetCollection(collectionKey, l.embedFn)
+	coll := l.db.GetCollection(collectionKey, chromem.EmbeddingFunc(l.embedFn))
 
 	ctx := context.Background()
 	id := 1


### PR DESCRIPTION
Move genkitSummarizer from main.go into internal/ai/genkit-summarizer, and rename internal/ai/gemini-embedding to internal/ai/genkit-embedding to reflect that these are genkit adapters, not gemini-specific.

Introduce rag.EmbeddingFunc so the RAG package decouples from chromem's type at its public API boundary; chromem conversion happens internally.