### PR TITLE
feat: implement auto-inject context files

### DIFF
--- a/cmd/server-bot/main.go
+++ b/cmd/server-bot/main.go
@@ -128,7 +128,17 @@ func main() {
 		Summarizer:     adapters.NewSummarizer(g, model),
 	})
 
-	personaStr := cfg.Personality.Role + "\n" + cfg.Personality.SystemPrompt
+	var autoInjectContent strings.Builder
+	for _, file := range cfg.Context.AutoInject {
+		content, err := os.ReadFile(file)
+		if err != nil {
+			logger.Warn("failed to load auto-inject file", slog.String("file", file), slog.String("error", err.Error()))
+			continue
+		}
+		autoInjectContent.WriteString(fmt.Sprintf("\n\n[System Context - File: %s]\n%s", file, string(content)))
+	}
+
+	personaStr := cfg.Personality.Role + "\n" + cfg.Personality.SystemPrompt + autoInjectContent.String()
 	aiLogic, err := agent.New(logger, g, model, hist, mcpClientAddrs, ragL, personaStr, customModelConfig)
 	if err != nil {
 		logger.Error("failed to create AI logic", slog.String("err", err.Error()))


### PR DESCRIPTION
Implemented the `auto_inject` feature to pre-load specified files once at the startup of the application. The content of these files is checked for reachability, and a warning is logged if an issue occurs. Their contents are dynamically appended to the System Prompt, ensuring they are injected into every LLM request without cluttering or polluting the conversation history cache.

---
*PR created automatically by Jules for task [51320230666192823](https://jules.google.com/task/51320230666192823) started by @Gerifield*