### PR TITLE
feat: implement mcp_cli stdio server logic

### DIFF
--- a/cmd/server-bot/main.go
+++ b/cmd/server-bot/main.go
@@ -147,9 +147,27 @@ func main() {
 	}
 
 	if cfg.RunMode == "mcp_cli" {
-		logger.Info("running in mcp_cli mode, awaiting MCP JSON-RPC over stdio (not yet implemented)")
-		// The CLI implementation will go here in a subsequent task.
-		// For now, gracefully exit.
+		logger.Info("running in mcp_cli mode, awaiting MCP JSON-RPC over stdio")
+
+		agentName := cfg.AgentConfig.AgentName
+		if agentName == "" {
+			agentName = "hairy-botter-agent"
+		}
+		agentDesc := cfg.AgentConfig.AgentDescription
+		if agentDesc == "" {
+			agentDesc = firstLine(aiLogic.Persona())
+		}
+
+		mcpSrv := mcpserver.New(aiLogic, mcpserver.Config{
+			Name:        agentName,
+			Description: agentDesc,
+			ToolNames:   aiLogic.ToolNames(),
+		})
+
+		if err := mcpSrv.StartStdio(); err != nil {
+			logger.Error("MCP stdio server failed", slog.String("err", err.Error()))
+			os.Exit(1)
+		}
 		return
 	}
 

--- a/internal/mcpserver/server.go
+++ b/internal/mcpserver/server.go
@@ -107,6 +107,11 @@ func (s *Server) Start(addr string) error {
 	return streamSrv.Start(addr)
 }
 
+// StartStdio runs the MCP server using standard input/output.
+func (s *Server) StartStdio() error {
+	return server.ServeStdio(s.mcpSrv)
+}
+
 func (s *Server) handleChat(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	msg := req.GetString("message", "")
 	if msg == "" {


### PR DESCRIPTION
This branch implements the planned `mcp_cli` mode using `github.com/mark3labs/mcp-go/server.ServeStdio`. It exposes the agent logic as MCP tools natively via standard input/output streams, which is typical for sub-agent tools, without starting any HTTP listeners.

---
*PR created automatically by Jules for task [16511050571866524168](https://jules.google.com/task/16511050571866524168) started by @Gerifield*