### PR TITLE
feat(mcp): support CLI-based MCP servers via stdio transport

### DIFF
--- a/cmd/server-bot/main.go
+++ b/cmd/server-bot/main.go
@@ -87,10 +87,15 @@ func main() {
 		}
 	}
 
-	var mcpClientAddrs []string
+	var mcpServers []agent.MCPServer
 	for _, srv := range cfg.Capabilities.MCPServers {
-		if srv.Type == "http" && srv.Path != "" {
-			mcpClientAddrs = append(mcpClientAddrs, srv.Path)
+		if srv.Path != "" {
+			mcpServers = append(mcpServers, agent.MCPServer{
+				Type: srv.Type,
+				Path: srv.Path,
+				Args: srv.Args,
+				Env:  srv.Env,
+			})
 		}
 	}
 
@@ -139,7 +144,7 @@ func main() {
 	}
 
 	personaStr := cfg.Personality.Role + "\n" + cfg.Personality.SystemPrompt + autoInjectContent.String()
-	aiLogic, err := agent.New(logger, g, model, hist, mcpClientAddrs, ragL, personaStr, customModelConfig)
+	aiLogic, err := agent.New(logger, g, model, hist, mcpServers, ragL, personaStr, customModelConfig)
 	if err != nil {
 		logger.Error("failed to create AI logic", slog.String("err", err.Error()))
 

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -44,7 +44,12 @@ capabilities:
     - type: http
       path: http://localhost:8081/mcp
     - type: cli
-      path: something
+      path: "go"
+      args:
+        - "run"
+        - "cmd/server-mcp-skills/main.go"
+      env:
+        MY_VAR: "value"
 
 
 # ---------------------------------------------------------

--- a/internal/ai/agent/logic.go
+++ b/internal/ai/agent/logic.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"os"
 
 	"hairy-botter/internal/ai/domain"
 	"hairy-botter/internal/rag"
@@ -14,6 +15,14 @@ import (
 	"github.com/firebase/genkit/go/genkit"
 	genkitMCP "github.com/firebase/genkit/go/plugins/mcp"
 )
+
+// MCPServer defines the configuration for a single MCP server.
+type MCPServer struct {
+	Type string
+	Path string
+	Args []string
+	Env  map[string]string
+}
 
 type historyLogic interface {
 	Read(ctx context.Context, sessionID string) ([]*ai.Message, error)
@@ -51,18 +60,51 @@ func (l *Logic) Persona() string {
 }
 
 // New .
-func New(logger *slog.Logger, g *genkit.Genkit, model ai.Model, history historyLogic, mcpClientAddrs []string, ragL *rag.Logic, persona string, extraOpts []ai.GenerateOption) (*Logic, error) {
+func New(logger *slog.Logger, g *genkit.Genkit, model ai.Model, history historyLogic, inputMCPServers []MCPServer, ragL *rag.Logic, persona string, extraOpts []ai.GenerateOption) (*Logic, error) {
 	var tools []ai.Tool
 
-	if len(mcpClientAddrs) > 0 {
-		mcpServers := make([]genkitMCP.MCPServerConfig, 0, len(mcpClientAddrs))
-		for i, addr := range mcpClientAddrs {
-			mcpServers = append(mcpServers, genkitMCP.MCPServerConfig{
+	if len(inputMCPServers) > 0 {
+		mcpServers := make([]genkitMCP.MCPServerConfig, 0, len(inputMCPServers))
+		for i, srv := range inputMCPServers {
+			cfg := genkitMCP.MCPServerConfig{
 				Name: fmt.Sprintf("mcp-client-%d", i), // Unique name for each client
-				Config: genkitMCP.MCPClientOptions{
-					StreamableHTTP: &genkitMCP.StreamableHTTPConfig{BaseURL: addr},
-				},
-			})
+			}
+
+			if srv.Type == "http" {
+				cfg.Config = genkitMCP.MCPClientOptions{
+					StreamableHTTP: &genkitMCP.StreamableHTTPConfig{BaseURL: srv.Path},
+				}
+			} else if srv.Type == "cli" {
+				if srv.Path == "" {
+					return nil, errors.New("empty cli path for mcp server")
+				}
+
+				// Build the environment
+				var env []string
+				// 1. Get from OS environment
+				for _, e := range os.Environ() {
+					env = append(env, e)
+				}
+				// 2. Override with config environment
+				if len(srv.Env) > 0 {
+					for k, v := range srv.Env {
+						env = append(env, fmt.Sprintf("%s=%s", k, v))
+					}
+				}
+
+				cfg.Config = genkitMCP.MCPClientOptions{
+					Stdio: &genkitMCP.StdioConfig{
+						Command: srv.Path,
+						Args:    srv.Args,
+						Env:     env,
+					},
+				}
+			} else {
+				logger.Warn("unknown mcp server type", slog.String("type", srv.Type))
+				continue
+			}
+
+			mcpServers = append(mcpServers, cfg)
 		}
 
 		logger.Info("MCP client list is not empty, initializing MCP clients")

--- a/internal/ai/agent/logic.go
+++ b/internal/ai/agent/logic.go
@@ -70,11 +70,20 @@ func New(logger *slog.Logger, g *genkit.Genkit, model ai.Model, history historyL
 				Name: fmt.Sprintf("mcp-client-%d", i), // Unique name for each client
 			}
 
-			if srv.Type == "http" {
+			serverType := srv.Type
+			if serverType == "" {
+				if len(srv.Path) >= 4 && srv.Path[:4] == "http" {
+					serverType = "http"
+				} else {
+					serverType = "cli"
+				}
+			}
+
+			if serverType == "http" {
 				cfg.Config = genkitMCP.MCPClientOptions{
 					StreamableHTTP: &genkitMCP.StreamableHTTPConfig{BaseURL: srv.Path},
 				}
-			} else if srv.Type == "cli" {
+			} else if serverType == "cli" {
 				if srv.Path == "" {
 					return nil, errors.New("empty cli path for mcp server")
 				}
@@ -100,7 +109,7 @@ func New(logger *slog.Logger, g *genkit.Genkit, model ai.Model, history historyL
 					},
 				}
 			} else {
-				logger.Warn("unknown mcp server type", slog.String("type", srv.Type))
+				logger.Warn("unknown mcp server type", slog.String("type", serverType))
 				continue
 			}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -60,8 +60,10 @@ type HistorySummaryConfig struct {
 
 // MCPServerConfig defines an external Tool Provider.
 type MCPServerConfig struct {
-	Type string `yaml:"type"`
-	Path string `yaml:"path"`
+	Type string            `yaml:"type"`
+	Path string            `yaml:"path"`
+	Args []string          `yaml:"args"`
+	Env  map[string]string `yaml:"env"`
 }
 
 // ContextConfig specifies files to inject automatically.


### PR DESCRIPTION
This change implements support for executing CLI-based MCP servers using the `genkitMCP.StdioConfig` transport mechanism.

- Adds `Args []string` and `Env map[string]string` to `config.MCPServerConfig`.
- Introduces `agent.MCPServer` domain model to decouple from the `config` package.
- Modifies `agent.New()` to parse both `http` and `cli` MCP configurations, merging local `os.Environ()` with the user's config env.
- Updates `config.yaml.example` to demonstrate CLI tool capability.

---
*PR created automatically by Jules for task [246167103401029751](https://jules.google.com/task/246167103401029751) started by @Gerifield*