### PR TITLE
feat: add WebSocket transport and migrate Telegram client

### DIFF
--- a/cmd/client-telegram/main.go
+++ b/cmd/client-telegram/main.go
@@ -2,9 +2,7 @@ package main
 
 import (
 	"context"
-	"errors"
 	"fmt"
-	"hairy-botter/pkg/httpBotter"
 	"io"
 	"net/http"
 	"os"
@@ -12,21 +10,18 @@ import (
 	"strings"
 	"sync"
 	"syscall"
-	"time"
 
 	"github.com/go-telegram/bot"
 	"github.com/go-telegram/bot/models"
-)
 
-// Send any text message to the bot after the bot has been started
+	"hairy-botter/pkg/wsBotter"
+)
 
 func main() {
 	token := os.Getenv("BOT_TOKEN")
 	if token == "" {
 		fmt.Println("BOT_TOKEN must be set")
-
 		os.Exit(1)
-		return
 	}
 
 	aiSrv := os.Getenv("AI_SERVICE")
@@ -35,8 +30,8 @@ func main() {
 	}
 
 	usernameLimits := make([]string, 0)
-	if usernameLimitsEnv := os.Getenv("USERNAME_LIMITS"); usernameLimitsEnv != "" {
-		for _, u := range strings.Split(usernameLimitsEnv, ",") {
+	if env := os.Getenv("USERNAME_LIMITS"); env != "" {
+		for _, u := range strings.Split(env, ",") {
 			usernameLimits = append(usernameLimits, strings.TrimSpace(u))
 		}
 	}
@@ -52,9 +47,7 @@ func main() {
 	b, err := bot.New(token, opts...)
 	if err != nil {
 		fmt.Println(err)
-
 		os.Exit(1)
-		return
 	}
 
 	l.bot = b
@@ -81,27 +74,68 @@ func main() {
 
 	b.Start(ctx)
 
-	// Graceful shutdown of HTTP server
+	l.closeAll()
+
 	if err := srv.Shutdown(context.Background()); err != nil {
 		fmt.Println("HTTP server shutdown error:", err)
 	}
 }
 
+// Logic holds per-instance state for the Telegram bot.
 type Logic struct {
-	httpB      *httpBotter.Logic
+	aiSrv      string
 	userLimits []string
-	chatID     int64
-	mu         sync.RWMutex
 	bot        *bot.Bot
+
+	// chatID is tracked so the push-notification HTTP handler can deliver
+	// messages to the most recently active chat.
+	mu     sync.RWMutex
+	chatID int64
+
+	// sessions maps "tg-{chatID}" → open WebSocket connection.
+	sessionMu sync.Mutex
+	sessions  map[string]*wsBotter.ConnectedClient
 }
 
-func New(baseURL string, userLimit []string) *Logic {
+// New creates a Logic ready to be wired to a Telegram bot.
+func New(aiSrv string, userLimit []string) *Logic {
 	return &Logic{
-		httpB:      httpBotter.New(baseURL),
+		aiSrv:      aiSrv,
 		userLimits: userLimit,
+		sessions:   make(map[string]*wsBotter.ConnectedClient),
 	}
 }
 
+// session returns the cached WebSocket connection for sessionID, dialling a
+// new one if necessary.
+func (l *Logic) session(ctx context.Context, sessionID string) (*wsBotter.ConnectedClient, error) {
+	l.sessionMu.Lock()
+	defer l.sessionMu.Unlock()
+
+	if c, ok := l.sessions[sessionID]; ok {
+		return c, nil
+	}
+
+	c, err := wsBotter.Dial(ctx, l.aiSrv, sessionID)
+	if err != nil {
+		return nil, err
+	}
+	l.sessions[sessionID] = c
+	return c, nil
+}
+
+// closeAll closes every open WebSocket session (called on shutdown).
+func (l *Logic) closeAll() {
+	l.sessionMu.Lock()
+	defer l.sessionMu.Unlock()
+	for id, c := range l.sessions {
+		c.Close()
+		delete(l.sessions, id)
+	}
+}
+
+// httpHandler lets external systems push a message to the most-recently-active
+// Telegram chat via POST / with a `payload` form field.
 func (l *Logic) httpHandler(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
@@ -128,7 +162,6 @@ func (l *Logic) httpHandler(w http.ResponseWriter, r *http.Request) {
 		ChatID:    chatID,
 		Text:      bot.EscapeMarkdownUnescaped(payload),
 	})
-
 	if err != nil {
 		fmt.Println("Error sending HTTP payload to Telegram:", err)
 		http.Error(w, "Failed to send message to Telegram", http.StatusInternalServerError)
@@ -136,31 +169,28 @@ func (l *Logic) httpHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.WriteHeader(http.StatusOK)
-	w.Write([]byte("Message sent successfully"))
+	_, _ = w.Write([]byte("Message sent successfully"))
 }
 
-// Handler .
+// Handler is the Telegram bot update handler.
 func (l *Logic) Handler(ctx context.Context, b *bot.Bot, update *models.Update) {
 	if update.Message == nil {
 		return
 	}
 
-	// If we have any limits set, check them
 	if len(l.userLimits) > 0 {
-		found := false
+		allowed := false
 		for _, u := range l.userLimits {
 			if update.Message.From.Username == u {
-				found = true
+				allowed = true
 				break
 			}
 		}
-
-		if !found {
+		if !allowed {
 			_, _ = b.SendMessage(ctx, &bot.SendMessageParams{
 				ChatID: update.Message.Chat.ID,
-				Text:   "🙅You are not allowed to use this bot.",
+				Text:   "You are not allowed to use this bot.",
 			})
-
 			return
 		}
 	}
@@ -169,25 +199,21 @@ func (l *Logic) Handler(ctx context.Context, b *bot.Bot, update *models.Update) 
 	l.chatID = update.Message.Chat.ID
 	l.mu.Unlock()
 
-	var payloads [][]byte
+	chatID := update.Message.Chat.ID
+	sessionID := fmt.Sprintf("tg-%d", chatID)
+
+	var payloads []wsBotter.InlineData
 	msg := update.Message.Text
 
 	if len(update.Message.Photo) > 0 {
-		highResImg := biggestImage(update.Message.Photo)
-		fmt.Println("photo file ID:", highResImg.FileID)
-		fmt.Printf("photo info: W: %d, H: %d, Size: %d\n", highResImg.Width, highResImg.Height, highResImg.FileSize)
-		fmt.Println("caption:", update.Message.Caption)
-		f, err := b.GetFile(ctx, &bot.GetFileParams{
-			FileID: highResImg.FileID,
-		})
+		photo := biggestImage(update.Message.Photo)
+		f, err := b.GetFile(ctx, &bot.GetFileParams{FileID: photo.FileID})
 		if err != nil {
 			fmt.Println("error getting file:", err)
 			return
 		}
 
-		// Download the file
-		dlURL := b.FileDownloadLink(f)
-		resp, err := http.Get(dlURL)
+		resp, err := http.Get(b.FileDownloadLink(f))
 		if err != nil {
 			fmt.Println("error downloading file:", err)
 			return
@@ -199,89 +225,70 @@ func (l *Logic) Handler(ctx context.Context, b *bot.Bot, update *models.Update) 
 			fmt.Println("error reading file:", err)
 			return
 		}
-		payloads = append(payloads, data)
+
+		payloads = append(payloads, wsBotter.InlineData{
+			MimeType: http.DetectContentType(data),
+			Data:     data,
+		})
 
 		if update.Message.Caption != "" {
 			msg = update.Message.Caption
 		}
 	}
 
-	// Start typing indicator in a background goroutine
-	doneCh := make(chan struct{})
-	go func() {
-		// Send immediately once
-		_, _ = b.SendChatAction(ctx, &bot.SendChatActionParams{
-			ChatID: update.Message.Chat.ID,
-			Action: models.ChatActionTyping,
+	// Send a single typing action; Telegram shows it for ~5 s then it expires
+	// automatically — no need for a background loop.
+	_, _ = b.SendChatAction(ctx, &bot.SendChatActionParams{
+		ChatID: chatID,
+		Action: models.ChatActionTyping,
+	})
+
+	wsClient, err := l.session(ctx, sessionID)
+	if err != nil {
+		fmt.Println("error connecting to AI service:", err)
+		_, _ = b.SendMessage(ctx, &bot.SendMessageParams{
+			ChatID: chatID,
+			Text:   "Sorry, I could not connect to the AI service.",
 		})
+		return
+	}
 
-		ticker := time.NewTicker(4 * time.Second)
-		defer ticker.Stop()
-
-		for {
-			select {
-			case <-ticker.C:
-				_, _ = b.SendChatAction(ctx, &bot.SendChatActionParams{
-					ChatID: update.Message.Chat.ID,
-					Action: models.ChatActionTyping,
-				})
-			case <-doneCh:
-				return
-			case <-ctx.Done():
-				return
-			}
-		}
-	}()
-
-	fmt.Println("Sending message to AI service:", msg)
-	res, err := l.httpB.Send(fmt.Sprintf("tg-%d", update.Message.Chat.ID), msg, payloads)
-
-	// Stop typing indicator
-	close(doneCh)
-
+	res, err := wsClient.Send(ctx, msg, payloads)
 	if err != nil {
 		fmt.Println("error sending message to AI service:", err)
 
-		var httpErr *httpBotter.HTTPError
-		if errors.As(err, &httpErr) {
-			errorMsg := fmt.Sprintf("Sorry, I encountered an error while processing your message.\nHTTP %d: %s", httpErr.StatusCode, httpErr.Body)
-			_, _ = b.SendMessage(ctx, &bot.SendMessageParams{
-				ChatID: update.Message.Chat.ID,
-				Text:   errorMsg,
-			})
-		} else {
-			_, _ = b.SendMessage(ctx, &bot.SendMessageParams{
-				ChatID: update.Message.Chat.ID,
-				Text:   "Sorry, I encountered an internal error while processing your message.",
-			})
-		}
+		// Invalidate the broken connection so the next request re-dials.
+		l.sessionMu.Lock()
+		delete(l.sessions, sessionID)
+		l.sessionMu.Unlock()
+
+		_, _ = b.SendMessage(ctx, &bot.SendMessageParams{
+			ChatID: chatID,
+			Text:   fmt.Sprintf("Sorry, I encountered an error: %v", err),
+		})
 		return
 	}
 
 	fmt.Println("AI service response:", res)
 	_, err = b.SendMessage(ctx, &bot.SendMessageParams{
 		ParseMode: models.ParseModeMarkdown,
-		ChatID:    update.Message.Chat.ID,
+		ChatID:    chatID,
 		Text:      bot.EscapeMarkdownUnescaped(res),
 	})
 	if err != nil {
 		fmt.Println("error sending response back to Telegram:", err)
-		return
 	}
-
 }
 
 func biggestImage(photos []models.PhotoSize) models.PhotoSize {
 	if len(photos) == 0 {
 		return models.PhotoSize{}
 	}
-
 	biggest := photos[0]
 	for _, photo := range photos {
 		if photo.FileSize > biggest.FileSize {
 			biggest = photo
 		}
 	}
-
 	return biggest
 }

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.25.0
 
 require (
 	github.com/briandowns/spinner v1.23.2
+	github.com/coder/websocket v1.8.14
 	github.com/firebase/genkit/go v1.7.0
 	github.com/go-chi/chi/v5 v5.2.1
 	github.com/go-telegram/bot v1.17.0
@@ -23,7 +24,6 @@ require (
 	cloud.google.com/go/compute/metadata v0.7.0 // indirect
 	github.com/bahlo/generic-list-go v0.2.0 // indirect
 	github.com/buger/jsonparser v1.1.1 // indirect
-	github.com/coder/websocket v1.8.14 // indirect
 	github.com/fatih/color v1.7.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect

--- a/internal/server/connections.go
+++ b/internal/server/connections.go
@@ -1,0 +1,64 @@
+package server
+
+import (
+	"context"
+	"sync"
+
+	"github.com/coder/websocket"
+	"github.com/coder/websocket/wsjson"
+)
+
+type wsConn struct {
+	conn *websocket.Conn
+	mu   sync.Mutex
+}
+
+func (c *wsConn) send(ctx context.Context, v any) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return wsjson.Write(ctx, c.conn, v)
+}
+
+// ConnectionManager manages WebSocket connections grouped by session ID.
+// Multiple clients may share a session and all receive broadcasts.
+type ConnectionManager struct {
+	mu       sync.RWMutex
+	sessions map[string][]*wsConn
+}
+
+func newConnectionManager() *ConnectionManager {
+	return &ConnectionManager{sessions: make(map[string][]*wsConn)}
+}
+
+func (m *ConnectionManager) register(sessionID string, c *wsConn) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.sessions[sessionID] = append(m.sessions[sessionID], c)
+}
+
+func (m *ConnectionManager) unregister(sessionID string, c *wsConn) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	conns := m.sessions[sessionID]
+	for i, existing := range conns {
+		if existing == c {
+			m.sessions[sessionID] = append(conns[:i], conns[i+1:]...)
+			break
+		}
+	}
+	if len(m.sessions[sessionID]) == 0 {
+		delete(m.sessions, sessionID)
+	}
+}
+
+// Broadcast sends msg to every connection registered under sessionID.
+func (m *ConnectionManager) Broadcast(ctx context.Context, sessionID string, msg any) {
+	m.mu.RLock()
+	conns := make([]*wsConn, len(m.sessions[sessionID]))
+	copy(conns, m.sessions[sessionID])
+	m.mu.RUnlock()
+
+	for _, c := range conns {
+		_ = c.send(ctx, msg)
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -22,20 +22,22 @@ type Config struct {
 
 // Server .
 type Server struct {
-	h     *chi.Mux
-	srv   *http.Server
-	logic ai
-	cfg   Config
+	h       *chi.Mux
+	srv     *http.Server
+	logic   ai
+	cfg     Config
+	connMgr *ConnectionManager
 }
 
 // New .
 func New(addr string, aiLogic ai, cfg Config) *Server {
 	h := chi.NewMux()
 	s := &Server{
-		h:     h,
-		srv:   &http.Server{Addr: addr, Handler: h},
-		logic: aiLogic,
-		cfg:   cfg,
+		h:       h,
+		srv:     &http.Server{Addr: addr, Handler: h},
+		logic:   aiLogic,
+		cfg:     cfg,
+		connMgr: newConnectionManager(),
 	}
 	s.addRoutes()
 
@@ -44,6 +46,7 @@ func New(addr string, aiLogic ai, cfg Config) *Server {
 
 func (s *Server) addRoutes() {
 	s.h.Post("/message", s.postMessage)
+	s.h.Get("/ws/{session_id}", s.wsHandler)
 
 	// CORS preflight request handler
 	s.h.Options("/*", func(w http.ResponseWriter, r *http.Request) {
@@ -52,6 +55,11 @@ func (s *Server) addRoutes() {
 		w.Header().Set("Access-Control-Allow-Headers", s.cfg.AllowedHeaders)
 		w.WriteHeader(http.StatusOK)
 	})
+}
+
+// Broadcast sends an event message to all WebSocket clients connected to sessionID.
+func (s *Server) Broadcast(ctx context.Context, sessionID string, msg any) {
+	s.connMgr.Broadcast(ctx, sessionID, msg)
 }
 
 // Start .

--- a/internal/server/websocket.go
+++ b/internal/server/websocket.go
@@ -1,0 +1,85 @@
+package server
+
+import (
+	"encoding/base64"
+	"fmt"
+	"net/http"
+
+	"github.com/coder/websocket"
+	"github.com/coder/websocket/wsjson"
+	"github.com/go-chi/chi/v5"
+
+	"hairy-botter/internal/ai/domain"
+)
+
+// WSMessage is the JSON envelope used on the WebSocket wire.
+type WSMessage struct {
+	Type    string `json:"type"`              // "message", "response", "error", "event"
+	Content string `json:"content,omitempty"` // text payload
+	Session string `json:"session,omitempty"` // echoed back in responses
+}
+
+// WSIncoming is a message sent by the client over WebSocket.
+type WSIncoming struct {
+	Message    string          `json:"message"`
+	InlineData []wsInlineData  `json:"inline_data,omitempty"`
+}
+
+type wsInlineData struct {
+	MimeType string `json:"mime_type"`
+	DataB64  string `json:"data"` // base64-encoded bytes
+}
+
+func (s *Server) wsHandler(w http.ResponseWriter, r *http.Request) {
+	sessionID := chi.URLParam(r, "session_id")
+	if sessionID == "" {
+		http.Error(w, "session_id required", http.StatusBadRequest)
+		return
+	}
+
+	conn, err := websocket.Accept(w, r, &websocket.AcceptOptions{
+		InsecureSkipVerify: true, // CORS is handled at a higher level
+	})
+	if err != nil {
+		return
+	}
+
+	wsc := &wsConn{conn: conn}
+	s.connMgr.register(sessionID, wsc)
+	defer func() {
+		s.connMgr.unregister(sessionID, wsc)
+		conn.CloseNow()
+	}()
+
+	ctx := r.Context()
+	for {
+		var in WSIncoming
+		if err := wsjson.Read(ctx, conn, &in); err != nil {
+			return
+		}
+
+		var inlineData []*domain.InlineData
+		for _, d := range in.InlineData {
+			raw, err := base64.StdEncoding.DecodeString(d.DataB64)
+			if err != nil {
+				_ = wsc.send(ctx, WSMessage{Type: "error", Content: fmt.Sprintf("invalid base64: %v", err), Session: sessionID})
+				continue
+			}
+			inlineData = append(inlineData, &domain.InlineData{
+				MimeType: d.MimeType,
+				Data:     raw,
+			})
+		}
+
+		res, err := s.logic.HandleMessage(ctx, sessionID, domain.Request{
+			Message:    in.Message,
+			InlineData: inlineData,
+		})
+		if err != nil {
+			_ = wsc.send(ctx, WSMessage{Type: "error", Content: err.Error(), Session: sessionID})
+			continue
+		}
+
+		_ = wsc.send(ctx, WSMessage{Type: "response", Content: res, Session: sessionID})
+	}
+}

--- a/pkg/wsBotter/client.go
+++ b/pkg/wsBotter/client.go
@@ -1,0 +1,167 @@
+// Package wsBotter provides a WebSocket client for the hairy-botter server.
+// It maintains a persistent connection to a named session, reconnects with
+// exponential backoff on failure, and delivers inbound server messages to a
+// caller-supplied handler.
+package wsBotter
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/coder/websocket"
+	"github.com/coder/websocket/wsjson"
+)
+
+// Message is the wire envelope exchanged with the server.
+type Message struct {
+	Type    string `json:"type"`
+	Content string `json:"content,omitempty"`
+	Session string `json:"session,omitempty"`
+}
+
+// InlineData carries a binary payload (e.g. an image) alongside a message.
+type InlineData struct {
+	MimeType string `json:"mime_type"`
+	Data     []byte `json:"-"`
+	DataB64  string `json:"data"` // populated automatically by Send
+}
+
+// outgoing is the client→server envelope.
+type outgoing struct {
+	Message    string       `json:"message"`
+	InlineData []InlineData `json:"inline_data,omitempty"`
+}
+
+// Client is a persistent WebSocket connection to one bot session.
+type Client struct {
+	baseURL   string
+	sessionID string
+	handler   func(Message)
+}
+
+// New creates a new Client. baseURL should be the HTTP root of the bot server
+// (e.g. "http://localhost:8080"). handler is called for every inbound Message.
+func New(baseURL, sessionID string, handler func(Message)) *Client {
+	return &Client{
+		baseURL:   baseURL,
+		sessionID: sessionID,
+		handler:   handler,
+	}
+}
+
+// Run connects to the server and blocks until ctx is cancelled. It reconnects
+// automatically with exponential backoff (1 s → 32 s) on connection failure.
+// Inbound messages are delivered to the handler registered at construction time.
+func (c *Client) Run(ctx context.Context) {
+	backoff := time.Second
+	for {
+		if err := c.connect(ctx); err != nil {
+			if ctx.Err() != nil {
+				return
+			}
+			fmt.Printf("wsBotter: connection error (%v), retrying in %s\n", err, backoff)
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(backoff):
+			}
+			if backoff < 32*time.Second {
+				backoff *= 2
+			}
+			continue
+		}
+		backoff = time.Second // reset on clean disconnect
+	}
+}
+
+func (c *Client) connect(ctx context.Context) error {
+	wsURL := fmt.Sprintf("%s/ws/%s", wsBase(c.baseURL), c.sessionID)
+	conn, _, err := websocket.Dial(ctx, wsURL, nil)
+	if err != nil {
+		return err
+	}
+	defer conn.CloseNow()
+
+	for {
+		var msg Message
+		if err := wsjson.Read(ctx, conn, &msg); err != nil {
+			return err
+		}
+		c.handler(msg)
+	}
+}
+
+func wsBase(baseURL string) string {
+	if len(baseURL) >= 5 && baseURL[:5] == "https" {
+		return "wss" + baseURL[5:]
+	}
+	if len(baseURL) >= 4 && baseURL[:4] == "http" {
+		return "ws" + baseURL[4:]
+	}
+	return baseURL
+}
+
+// ConnectedClient holds an open WebSocket connection and can send messages on it.
+type ConnectedClient struct {
+	conn      *websocket.Conn
+	sessionID string
+}
+
+// Dial opens a connection and returns a ConnectedClient.
+func Dial(ctx context.Context, baseURL, sessionID string) (*ConnectedClient, error) {
+	wsURL := fmt.Sprintf("%s/ws/%s", wsBase(baseURL), sessionID)
+	conn, _, err := websocket.Dial(ctx, wsURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &ConnectedClient{conn: conn, sessionID: sessionID}, nil
+}
+
+// Send transmits a message and waits for the first response.
+// payloads may be nil.
+func (c *ConnectedClient) Send(ctx context.Context, msg string, payloads []InlineData) (string, error) {
+	for i := range payloads {
+		payloads[i].DataB64 = base64.StdEncoding.EncodeToString(payloads[i].Data)
+	}
+
+	out := outgoing{Message: msg, InlineData: payloads}
+	raw, err := json.Marshal(out)
+	if err != nil {
+		return "", err
+	}
+	if err := c.conn.Write(ctx, websocket.MessageText, raw); err != nil {
+		return "", fmt.Errorf("write: %w", err)
+	}
+
+	var resp Message
+	if err := wsjson.Read(ctx, c.conn, &resp); err != nil {
+		return "", fmt.Errorf("read: %w", err)
+	}
+	if resp.Type == "error" {
+		return "", fmt.Errorf("server error: %s", resp.Content)
+	}
+	return resp.Content, nil
+}
+
+// ReadAsync starts a goroutine that delivers all inbound messages to handler
+// until ctx is cancelled or the connection is closed.
+func (c *ConnectedClient) ReadAsync(ctx context.Context, handler func(Message)) {
+	go func() {
+		for {
+			var msg Message
+			if err := wsjson.Read(ctx, c.conn, &msg); err != nil {
+				return
+			}
+			handler(msg)
+		}
+	}()
+}
+
+// Close closes the connection.
+func (c *ConnectedClient) Close() {
+	c.conn.CloseNow()
+}
+


### PR DESCRIPTION
- Add GET /ws/{session_id} handler to the bot server using coder/websocket
- Implement thread-safe ConnectionManager (session → []conn) with Broadcast() for future server-initiated pushes (e.g. from MCP tools)
- Add pkg/wsBotter with ConnectedClient (persistent per-session conn) and Client (reconnecting listener with exponential backoff)
- Migrate Telegram client from HTTP to WebSocket: one ConnectedClient per chat, cached by session ID, evicted on error so next message re-dials
- Replace background typing-indicator loop with a single SendChatAction call